### PR TITLE
Fix #5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rstatscn
 Type: Package
 Title: R Interface for China National Data
-Version: 1.1.3
+Version: 1.1.4
 Date: 2019-04-25
 Author: Xuehui YANG
 Maintainer: Xuehui YANG <jianghang@bagualu.net>
@@ -15,4 +15,5 @@ URL: http://www.bagualu.net/
 BugReports: http://www.bagualu.net/wordpress/rstatscn-the-r-interface-for-china-national-data
 Repository: CRAN
 License: Apache License 2.0
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.2
+Encoding: UTF-8

--- a/R/rstatscn.R
+++ b/R/rstatscn.R
@@ -9,7 +9,6 @@ NULL
 NULL
 
 statscnbase<-'https://data.stats.gov.cn/easyquery.htm'
-set_config(config(ssl_verifypeer = FALSE))
 rstatscnEnv<-new.env()
 assign('prefix',NULL, envir=rstatscnEnv)
 

--- a/R/rstatscn.R
+++ b/R/rstatscn.R
@@ -83,14 +83,19 @@ dataJson2df<-function(rawObj,rowcode,colcode)
         #dataStructure
 	#jj is a list
         #jj[[1]] = 200 #return code
-        #jj[[2]] is datanode
-        #jj[[2]][[1]] is data
-        #jj[[2]][[2]] is description
-        #jj[[2]][[2]][,"nodes"][[1]] is row description , it is a dataframe
-        #jj[[2]][[2]][,"nodes"][[2]] is col description , it is a dataframe
-        desList=ret[[2]][[2]][,'nodes']
-	rowWdIdx = which(ret[[2]][[2]]$wdcode == rowcode) 
-	colWdIdx = which(ret[[2]][[2]]$wdcode == colcode) 
+        #jj[[2]] is returndata
+	returnData = "returndata"
+        #jj[[2]][[1]] is datanodes
+	dataNodes = "datanodes"
+        #jj[[2]][[2]] is freshsort
+	      #jj[[2]][[3]] is data
+        #jj[[2]][[4]] is wdnodes (description)
+	descriptionNodes = "wdnodes"
+        #jj[[2]][[4]][,"nodes"][[1]] is row description , it is a dataframe
+        #jj[[2]][[4]][,"nodes"][[2]] is col description , it is a dataframe
+        desList=ret[[returnData]][[descriptionNodes]][,'nodes']
+	rowWdIdx = which(ret[[returnData]][[descriptionNodes]]$wdcode == rowcode) 
+	colWdIdx = which(ret[[returnData]][[descriptionNodes]]$wdcode == colcode) 
         rowDes=desList[[rowWdIdx]]
         colDes=desList[[colWdIdx]]
 
@@ -119,7 +124,7 @@ dataJson2df<-function(rawObj,rowcode,colcode)
         myret=as.data.frame(matrix(rep(NA,rowNum*colNum),nrow=rowNum))
         rownames(myret)=rowCodes
         colnames(myret)=colCodes
-        dfdata=ret[[2]][[1]]
+        dfdata=ret[[returnData]][[dataNodes]]
         for (k in seq(1,nrow(dfdata))) {
 		wddf=dfdata[k,"wds"][[1]]
 		myret[wddf[rowWdIdx,'valuecode'],wddf[colWdIdx,'valuecode']] = dfdata[k,'data'][1,'data']

--- a/R/rstatscn.R
+++ b/R/rstatscn.R
@@ -8,7 +8,8 @@ NULL
 #' @import jsonlite
 NULL
 
-statscnbase<-'http://data.stats.gov.cn/easyquery.htm'
+statscnbase<-'https://data.stats.gov.cn/easyquery.htm'
+set_config(config(ssl_verifypeer = FALSE))
 rstatscnEnv<-new.env()
 assign('prefix',NULL, envir=rstatscnEnv)
 

--- a/R/rstatscn.R
+++ b/R/rstatscn.R
@@ -27,18 +27,31 @@ milSec<-function()
 #' the available dbs
 #' 
 #' the available dbs in the national db
-#' @return a data frame with 2 columns , one is the dbcode, another is the db description 
+#' @return a data frame with 3 columns , first is the dbcode, second is the db description, third is the db description in Chinese
 #' @export 
 #' @examples 
 #'  statscnDbs()
 statscnDbs<-function()
 {
-	dbs <- c("hgnd","hgjd","hgyd","fsnd","fsjd","fsyd","csnd","csyd","gjnd","gjyd","gjydsdj")
-	dbnames <- c("national data, yearly","national data,  quaterly","national data, monthly",
-		     "province data, yearly","province data, quaterly","province data, monthly",
-                     "city data, yearly","city data, monthly", "international data, yearly", 
-                     "international data, monthly","3 main countries data, monthly")
-	ret=data.frame(dbcode=dbs,description=dbnames)
+	dbs <- c("hgnd","hgjd","hgyd",
+	         "fsnd","fsjd","fsyd",
+	         "csnd","csyd",
+	         "gatnd","gatyd",
+	         "gjnd","gjyd",
+	         "gjydsdj","gjydsc")
+	dbnames <- c("national data, yearly","national data, quarterly","national data, monthly",
+		     "province data, yearly","province data, quarterly","province data, monthly",
+                     "city data, yearly","city data, monthly",
+		     "Hong Kong, Macao, Taiwan data, yearly", "Hong Kong, Macao, Taiwan data, monthly",
+		     "international data, yearly", "international data, monthly",
+		     "3 main countries data, monthly", "international market commodity prices, monthly")
+	dbnameschinese <- c("宏观年度","宏观季度","宏观月度",
+	                    "分省年度","分省季度","分省月度",
+	                    "城市年度","城市月度",
+	                    "港澳台年度","港澳台月度",
+	                    "国际年度","国际月度",
+	                    "三大经济体月度","国际市场月度商品价格")
+	ret=data.frame(dbcode=dbs,description=dbnames,description_zh=dbnameschinese)
 	return(ret)
 }
 

--- a/R/rstatscn.R
+++ b/R/rstatscn.R
@@ -44,12 +44,12 @@ statscnDbs<-function()
 		     "Hong Kong, Macao, Taiwan data, yearly", "Hong Kong, Macao, Taiwan data, monthly",
 		     "international data, yearly", "international data, monthly",
 		     "3 main countries data, monthly", "international market commodity prices, monthly")
-	dbnameschinese <- c("宏观年度","宏观季度","宏观月度",
-	                    "分省年度","分省季度","分省月度",
-	                    "城市年度","城市月度",
-	                    "港澳台年度","港澳台月度",
-	                    "国际年度","国际月度",
-	                    "三大经济体月度","国际市场月度商品价格")
+	dbnameschinese <- c("\u5B8F\u89C2\u5E74\u5EA6","\u5B8F\u89C2\u5B63\u5EA6","\u5B8F\u89C2\u6708\u5EA6",# "宏观年度","宏观季度","宏观月度",
+	                    "\u5206\u7701\u5E74\u5EA6","\u5206\u7701\u5B63\u5EA6","\u5206\u7701\u6708\u5EA6",# "分省年度","分省季度","分省月度",
+	                    "\u57CE\u5E02\u5E74\u5EA6","\u57CE\u5E02\u6708\u5EA6",# "城市年度","城市月度",
+	                    "\u6E2F\u6FB3\u53F0\u5E74\u5EA6","\u6E2F\u6FB3\u53F0\u6708\u5EA6",# "港澳台年度","港澳台月度",
+	                    "\u56FD\u9645\u5E74\u5EA6","\u56FD\u9645\u6708\u5EA6",# "国际年度","国际月度",
+	                    "\u4E09\u5927\u7ECF\u6D4E\u4F53\u6708\u5EA6","\u56FD\u9645\u5E02\u573A\u6708\u5EA6\u5546\u54C1\u4EF7\u683C")# "三大经济体月度","国际市场月度商品价格"
 	ret=data.frame(dbcode=dbs,description=dbnames,description_zh=dbnameschinese)
 	return(ret)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,7 @@
+.onLoad <- function(libname, pkgname) {
+  httr::set_config(config(ssl_verifypeer = FALSE))
+}
+
+.onUnload <- function(libpath) {
+  httr::reset_config()
+}

--- a/README.md
+++ b/README.md
@@ -81,18 +81,21 @@ github page: https://github.com/jiang-hang/rstatscn
 ```R
 > library(rstatscn)
 > statscnDbs()
-    dbcode                    description
-1     hgnd          national data, yearly   #宏观年度数据
-2     hgjd       national data,  quaterly   #宏观季度
-3     hgyd         national data, monthly   #宏观月度
-4     fsnd          province data, yearly   #分省年度
-5     fsjd        province data, quaterly   #分省季度
-6     fsyd         province data, monthly   #分省月度
-7     csnd              city data, yearly   #城市年度
-8     csyd             city data, monthly   #城市月度
-9     gjnd     international data, yearly   #国际年度
-10    gjyd    international data, monthly   #国际月度
-11 gjydsdj 3 main countries data, monthly   #三个主要国家月度数据
+    dbcode                                    description       description_zh
+1     hgnd                          national data, yearly             宏观年度
+2     hgjd                       national data, quarterly             宏观季度
+3     hgyd                         national data, monthly             宏观月度
+4     fsnd                          province data, yearly             分省年度
+5     fsjd                       province data, quarterly             分省季度
+6     fsyd                         province data, monthly             分省月度
+7     csnd                              city data, yearly             城市年度
+8     csyd                             city data, monthly             城市月度
+9    gatnd          Hong Kong, Macao, Taiwan data, yearly           港澳台年度
+10   gatyd         Hong Kong, Macao, Taiwan data, monthly           港澳台月度
+11    gjnd                     international data, yearly             国际年度
+12    gjyd                    international data, monthly             国际月度
+13 gjydsdj                 3 main countries data, monthly       三大经济体月度
+14  gjydsc international market commodity prices, monthly 国际市场月度商品价格
 ```
 ```R
 > statscnQueryZb(dbcode='hgnd')

--- a/README.md
+++ b/README.md
@@ -1,87 +1,100 @@
+
 # rstatscn
 
 rstatscn是一个R包，它提供了一些访问中国国家数据的一些方便的接口。可以比较方便的获取想要的国家数据。
 安装方法
 
-```{.r}
+```R
 install.packages('rstatscn')
 ```
 
 它可以方便的获取各种国家统计数据。比如中国的每年人口数据，各省的GDP数据，各种教育数据等。
 
-简介 
-最近版本 
-函数介绍 
-常见问题 
-其他 
-实例
-查询可用的数据库和指标 
-查询数据库中的数据 — 基础查询 
-查询数据库中的数据 — 分省数据查询 
-分省数据查询— 同时查询所有省份的数据 
+# 目录
+ - 简介  
+ - 最近版本  
+ - 函数介绍  
+ - 常见问题  
+ - 其他  
+ - 实例 
+ - 查询可用的数据库和指标  
+ - 查询数据库中的数据 — 基础查询  
+ - 查询数据库中的数据 — 分省数据查询  
+ - 分省数据查询 — 同时查询所有省份的数据
 
-简介
-rstatscn是一个R包，它提供了一些访问中国国家数据的一些方便的接口。可以在R中获取想要的国家数据，比如中国的每年人口数据，各省的GDP数据，各种教育数据等。安装方法
+# 简介
+rstatscn是一个R包，它提供了一些访问中国国家数据的一些方便的接口。可以在R中获取想要的国家数据，比如中国的每年人口数据，各省的GDP数据，各种教育数据等
 
+## 安装方法
+
+```R
 install.packages('rstatscn')
+```
 github page: https://github.com/jiang-hang/rstatscn
 
-最近版本
-2016.7.21 版本 1.1.1
+# 最近版本
+## 2016.7.21 版本 1.1.1
 
-修复行名重复的问题，如果你碰到这个问题
+- 修复行名重复的问题，如果你碰到这个问题
+`Error in row.names<-.data.frame(*tmp*, value = value): duplicate 'row.names' are not allowed`
+请首先调用`statscnRowNamePrefix()`,然后再查询数据库，这样在生成的dataframe中行的名字前会添加一个行号。要取消行号，调用`statscnRowNamePrefix(NULL)`
 
-Error in row.names<-.data.frame(*tmp*, value = value) : duplicate ‘row.names’ are not allowed
+## 2016.2.25 版本 1.0.2
+- 修复一个http状态检查的bug，需要httr >= 1.1.0
 
-请首先调用statscnRowNamePrefix(),然后再查询数据库，这样在生成的dataframe中行的名字前会添加一个行号。
+# 函数介绍
+成功安装了rstatscn以后，可以利用`help(package="rstatscn")`获得在线帮助。用`help(<函数名>)`获得函数的说明。
+ ## `statscnDbs()`
+   列出国家数据库中可用的数据库，其中数据库的代码很重要，后面的函数查询中需要设定要查询数据库的代码 
+ ## `statscnQueryZb(zbid='zb', dbcode='hgnd')`
+ 查询给定数据库中可用的指标。数据库中的指标是以树的结构组织的。查询根结点下的可用指标时，传入`zbid='zb'`即可。在获取的指标数据框中，如果这个指标不是叶节点，可以再利用这个函数来获得其子指标。如果`zbid`指定的指标已经是叶节点，那么将返回空的数据框。 
+ ## `statscnRegions(dbcode='fsnd')`
+ 获得指定数据库中的区域代码。这个函数可以用来获取各省的代码。获取省的代码以后，可以查询指定省份的数据。在城市数据库中，可以用来获得城市代码。国际数据库中，用来获得国家的代码 
+ ## `statscnQueryData(zb,dbcode,rowcode,colcode,moreWd)`
+   这个是真正的数据查询函数，其中`zb`要查询的指标`id`，这个`id`不能随便写，需要根据`statscnQueryZbs`函数的返回值来设定 
+ ## `dbcode` 
+ 要查询的数据库的代码，来源于`statscnDbs()`函数
+ ## `rowcode`
+ 返回数据框的行代码，缺省值为`zb`，即指标，一般设为缺省值即可
+ ## `colcode`
+ 返回数据框的列代码，缺省值为sj，即时间，一般设为缺省值即可
+ ## `moreWd`
+   对查询数据的更多限制。参数的格式为`moreWd=list(name=NA,value=NA)`。比如说在省份数据库中，在指定了要查询的zb以后，还可通过这个参数指定需要查询的省份。更多可见后面的例子。
+ ## `statscnQueryLastN(n)`
+   修改前一次查询，查询最新的n条数据，每次查询时，会缺省返回一些数据，如果你想获得更多的数据或者更少的数据，可以利用这个函数。这个函数只是修改返回数据的条数。注意，这个函数要在`statscnQueryData`之后调用，不然他不知道要修改哪条查询。
 
-要取消行号，调用statscnRowNamePrefix(NULL)
-
-2016.2.25 版本 1.0.2 修复一个http状态检查的bug，需要httr >= 1.1.0
-
-函数介绍
-成功安装了rstatscn以后，可以利用help(package="rstatscn")获得在线帮助。用help(<函数名>)获得函数的说明。
-
-statscnDbs() 列出国家数据库中可用的数据库，其中数据库的代码很重要，后面的函数查询中需要设定要查询数据库的代码 
-statscnQueryZb(zbid=’zb’, dbcode=’hgnd’) 查询给定数据库中可用的指标。数据库中的指标是以树的结构组织的。查询根结点下的可用指标时，传入zbid=’zb’ 即可。在获取的指标数据框中，如果这个指标不是叶节点，可以再利用这个函数来获得其子指标。如果zbid指定的指标已经是叶节点，那么将返回空的数据框。 
-statscnRegions(dbcode=’fsnd’) 获得指定数据库中的区域代码。这个函数可以用来获取各省的代码。获取省的代码以后，可以查询指定省份的数据。在城市数据库中，可以用来获得城市代码。国际数据库中，用来获得国家的代码 
-statscnQueryData(zb,dbcode,rowcode,colcode,moreWd) 这个是真正的数据查询函数，其中 
-zb 要查询的指标id，这个id不能随便写，需要根据statscnQueryZbs函数的返回值来设定 
-dbcode 要查询的数据库的代码，来源于statscnDbs()函数 
-rowcode 返回数据框的行代码，缺省值为zb，即指标，一般设为缺省值即可 
-colcode 返回数据框的列代码，缺省值为sj，即时间，一般设为缺省值即可 
-moreWd 对查询数据的更多限制。参数的格式为moreWd=list(name=NA,value=NA)。比如说在省份数据库中，在指定了要查询的zb以后，还可通过这个参数指定需要查询的省份。更多可见后面的例子。 
-statscnQueryLastN(n) 修改前一次查询，查询最新的n条数据，每次查询时，会缺省返回一些数据，如果你想获得更多的数据或者更少的数据，可以利用这个函数。这个函数只是修改返回数据的条数。注意，这个函数要在statscnQueryData之后调用，不然他不知道要修改哪条查询。 
-常见问题
-找不到rstatscn包？
+# 常见问题
+## 找不到rstatscn包？
 检查一下你R的版本，rstatscn在3.2.2及以上版本才可用。（因为没有在低版本测试过）
 
-数据的实时性怎样？
+## 数据的实时性怎样？
 函数获取的数据和网站http://data.stats.gov.cn中展示的数据是一致的。 如果获取的数据和网站展示的数据不一致，那应该是一个程序错误，可以告诉我
 
-其他
+## 其他
 我把国家数据库中的所有指标都列出来了。放在这里，以后就不必要每次去查了。 (2015-11-30日数据，仅供参考)
 
-在每个叶子指标下可能还会有多个指标，比如A0101行政区划下，还有11个指标，这个可以通过statscnQueryData(‘A0101’)的返回值 看到。这些指标也有自己的id，按照返回的行的顺序，id分别为A0101 + 0<行号>，9以后的编码为字母A,B,… 比如第一行—地级区划数(个)—的id为A010101 , 第11行的指标—-街道办事处(个)—-id 为A01010B。知道了这些指标的id以后，可以通过statscnQueryData(‘A01010B’)来直接查询这个指标，这样就不会返回一系列的指标值了。
+在每个叶子指标下可能还会有多个指标，比如`A0101`行政区划下，还有11个指标，这个可以通过`statscnQueryData('A0101')`的返回值 看到。这些指标也有自己的`id`，按照返回的行的顺序，`id`分别为`A0101 + 0<行号>`，`9`以后的编码为字母`A,B,…`比如第一行—地级区划数(个)—的`id`为`A010101` , 第11行的指标——街道办事处(个)——`id` 为`A01010B`。知道了这些指标的id以后，可以通过`statscnQueryData('A01010B')`来直接查询这个指标，这样就不会返回一系列的指标值了。
 
-实例
-查询可用的数据库和指标
-首先利用statscnDbs查询可用数据库，然后可根据数据库名字查询各数据库可用的指标。如下所示：
-
+# 实例
+## 查询可用的数据库和指标
+首先利用`statscnDbs`查询可用数据库，然后可根据数据库名字查询各数据库可用的指标。如下所示：
+```R
 > library(rstatscn)
 > statscnDbs()
     dbcode                    description
 1     hgnd          national data, yearly   #宏观年度数据
 2     hgjd       national data,  quaterly   #宏观季度
-3     hgyd         national data, monthly  #宏观月度
+3     hgyd         national data, monthly   #宏观月度
 4     fsnd          province data, yearly   #分省年度
 5     fsjd        province data, quaterly   #分省季度
 6     fsyd         province data, monthly   #分省月度
-7     csnd              city data, yearly         #城市年度
-8     csyd             city data, monthly      #城市月度
-9     gjnd     international data, yearly    #国际年度
+7     csnd              city data, yearly   #城市年度
+8     csyd             city data, monthly   #城市月度
+9     gjnd     international data, yearly   #国际年度
 10    gjyd    international data, monthly   #国际月度
-11 gjydsdj 3 main countries data, monthly    #三个主要国家月度数据
+11 gjydsdj 3 main countries data, monthly   #三个主要国家月度数据
+```
+```R
 > statscnQueryZb(dbcode='hgnd')
    dbcode  id isParent                     name pid wdcode
 1    hgnd A01     TRUE                     综合         zb
@@ -112,6 +125,8 @@ statscnQueryLastN(n) 修改前一次查询，查询最新的n条数据，每次�
 26   hgnd A0Q     TRUE                     文化         zb
 27   hgnd A0R     TRUE                     体育         zb
 28   hgnd A0S     TRUE 公共管理、社会保障及其他         zb
+```
+```R
 > statscnQueryZb('A01',dbcode='hgnd')
   dbcode    id isParent                   name pid wdcode
 1   hgnd A0101    FALSE               行政区划 A01     zb
@@ -119,9 +134,12 @@ statscnQueryLastN(n) 修改前一次查询，查询最新的n条数据，每次�
 3   hgnd A0103     TRUE             法人单位数 A01     zb
 4   hgnd A0104     TRUE         企业法人单位数 A01     zb
 5   hgnd A0105     TRUE           民族自治地方 A01     zb
-查询数据库中的数据 — 基础查询
-知道了数据库中的指标以后，就可以根据指标和数据库来查询数据了。通常要查询更多的数据，需要两次查询。如下所示：
+```
 
+## 查询数据库中的数据
+### 基础查询
+知道了数据库中的指标以后，就可以根据指标和数据库来查询数据了。通常要查询更多的数据，需要两次查询。如下所示：
+```R
 > statscnQueryData('A0102',dbcode='hgnd')
                            2014年     2013年      2012年
 粮食人均占有量(公斤)            0 443.456070  436.500957
@@ -140,6 +158,8 @@ statscnQueryLastN(n) 修改前一次查询，查询最新的n条数据，每次�
 人均水泥产量(公斤)              0   0.000000 1636.076835
 人均粗钢产量(公斤)              0   0.000000  535.933131
 人均发电量(千瓦小时)            0   0.000000 3692.582707
+```
+```R
 > statscnQueryLastN(4)
                            2014年     2013年      2012年      2011年
 粮食人均占有量(公斤)            0 443.456070  436.500957  425.152645
@@ -158,15 +178,17 @@ statscnQueryLastN(n) 修改前一次查询，查询最新的n条数据，每次�
 人均水泥产量(公斤)              0   0.000000 1636.076835 1561.797296
 人均粗钢产量(公斤)              0   0.000000  535.933131  509.833945
 人均发电量(千瓦小时)            0   0.000000 3692.582707 3506.371408
-查询数据库中的数据 — 分省数据查询
+```
+### 分省数据查询
 对于分省数据库而言，可以首先查询省份（即地区）的代码，然后再根据省份代码和指标来查询给定年/月度的数据。
-
+```R
 > statscnQueryZb('A01',dbcode='fsnd')
   dbcode    id isParent           name pid wdcode
 1   fsnd A0101    FALSE       行政区划 A01     zb
 2   fsnd A0102     TRUE     法人单位数 A01     zb
 3   fsnd A0103     TRUE 企业法人单位数 A01     zb
-
+```
+```R
 > statscnRegions(dbcode='fsnd')
    regCode             name
 1   110000           北京市
@@ -200,8 +222,10 @@ statscnQueryLastN(n) 修改前一次查询，查询最新的n条数据，每次�
 29  630000           青海省
 30  640000   宁夏回族自治区
 31  650000 新疆维吾尔自治区
+```
 
-#获取分省年度数据库中天津的A0101指标
+#### 获取分省年度数据库中天津的A0101指标
+```R
 > statscnQueryData('A0101',dbcode='fsnd',moreWd=list(name='reg',value='120000'))
                  2014年 2013年 2012年 2011年
 地级区划数(个)        0      0      0      0
@@ -215,12 +239,15 @@ statscnQueryLastN(n) 修改前一次查询，查询最新的n条数据，每次�
 镇数(个)            121    121    123    123
 乡数(个)              6      6     11     11
 街道办事处(个)      113    113    111    110
-#获取最近20年的天津A0101指标
+```
+#### 获取最近20年的天津A0101指标
+```R
 >statscnQueryLastN(20)
 ...
-分省数据查询— 同时查询所有省份的数据
-每次查询返回的数据是一个二维的表格，缺省情况下，行为指标，列为时间。要查询所有省的数据，只需要指定指标和数据库名，然后指定行为省份，即rowcode='reg',如下所示。注意这里的A010101指标是地级区划个数。因此，要查询所有省份的数据，需要精确指定指标代码，指定组的代码将会返回该组的第一个自指标数据。比如指定A0101,返回的数据实际上是A010101的数据。
-
+```
+### 同时查询所有省份的数据
+每次查询返回的数据是一个二维的表格，缺省情况下，行为指标，列为时间。要查询所有省的数据，只需要指定指标和数据库名，然后指定行为省份，即`rowcode='reg'`，如下所示。注意这里的`A010101`指标是地级区划个数。因此，要查询所有省份的数据，需要精确指定指标代码，指定组的代码将会返回该组的第一个自指标数据。比如指定`A0101`，返回的数据实际上是`A010101`的数据。
+```R
 > statscnQueryData("A010101",dbcode='fsnd',rowcode='reg')
                  2014年 2013年 2012年 2011年 2010年 2009年 2008年 2007年 2006年
 北京市                0      0      0      0      0      0      0      0      0
@@ -254,9 +281,12 @@ statscnQueryLastN(n) 修改前一次查询，查询最新的n条数据，每次�
 青海省                8      8      8      8      8      8      8      8      8
 宁夏回族自治区        5      5      5      5      5      5      5      5      5
 新疆维吾尔自治区     14     14     14     14     14     14     14     14     14
-如果要查询一组指标或查询给定年度的数据必须指定时间。指定时间的方式是使用参数moreWd=list((name='sj'),value='2015')1。然后通过rowcode='reg'指定返回表格的行为省份，colcode='zb'指定列为指标。如下所示：
+```
+如果要查询一组指标或查询给定年度的数据必须指定时间。指定时间的方式是使用参数`moreWd=list((name='sj'),value='2015')`<sup>1</sup>。然后通过`rowcode='reg'`指定返回表格的行为省份，`colcode='zb'`指定列为指标。如下所示：
 
-#获取所有省份2015年的A010101指标
+
+#### 获取所有省份2015年的A010101指标
+```R
 > statscnQueryData('A010101',dbcode='fsnd',rowcode='reg',colcode='zb',moreWd=list((name='sj'),value='2015'))
       地级区划数
  北京市                    0
@@ -290,9 +320,11 @@ statscnQueryLastN(n) 修改前一次查询，查询最新的n条数据，每次�
  青海省                    8
  宁夏回族自治区            5
  新疆维吾尔自治区         14
+  ```
                  
-#获取所有省份2015年的A0101指标
-#和上面的命令相比，这个会取出所有A0101下的子指标
+#### 获取所有省份2015年的`A0101`指标
+和上面的命令相比，这个会取出所有`A0101`下的子指标
+```R
 > statscnQueryData('A0101',dbcode='fsnd',rowcode='reg',colcode='zb',moreWd=list((name='sj'),value='2015'))
                  地级区划数 地级市数 县级区划数 市辖区数 县级市数 县数 自治县数
 北京市                    0        0         16       14        0    2        0
@@ -328,7 +360,7 @@ statscnQueryLastN(n) 修改前一次查询，查询最新的n条数据，每次�
 新疆维吾尔自治区         14        2        103       11       24   62        6
 
 #后面还有几个指标，这里略去
-
+```
 --------------------------------------------------------------------------------
 
-这里好象有个bug，如果name='sj'不加括号会报错。报错的内容为Error in seq.default(1, nrow(dfdata)) : 'to' must be of length 1↩
+1. 这里好象有个bug，如果`name='sj'`不加括号会报错。报错的内容为`Error in seq.default(1, nrow(dfdata)) : 'to' must be of length 1`

--- a/man/statscnDbs.Rd
+++ b/man/statscnDbs.Rd
@@ -7,7 +7,7 @@
 statscnDbs()
 }
 \value{
-a data frame with 2 columns , one is the dbcode, another is the db description
+a data frame with 3 columns , first is the dbcode, second is the db description, third is the db description in Chinese
 }
 \description{
 the available dbs in the national db

--- a/man/statscnQueryData.Rd
+++ b/man/statscnQueryData.Rd
@@ -4,8 +4,14 @@
 \alias{statscnQueryData}
 \title{query data in the statscn db}
 \usage{
-statscnQueryData(zb = "A0201", dbcode = "hgnd", rowcode = "zb",
-  colcode = "sj", moreWd = list(name = NA, value = NA))
+statscnQueryData(
+  zb = "A0201",
+  dbcode = "hgnd",
+  rowcode = "zb",
+  colcode = "sj",
+  moreWd = list(name = NA, value = NA),
+  lang = "zh"
+)
 }
 \arguments{
 \item{zb}{the zb/category code to be queried}
@@ -21,6 +27,8 @@ where the name should be one of c("reg","sj") , which stand for region and sj/ti
 the valuecode for reg should be the region code queried by statscnRegions()
 the valuecode for sj should be like '2014' for *nd , '2014C' for *jd , '201405' for *yd.
 Be noted that , the moreWd name should be different with either rowcode or colcode}
+
+\item{lang}{string value, one of c("zh","en")}
 }
 \value{
 the data frame you are quering

--- a/man/statscnQueryLastN.Rd
+++ b/man/statscnQueryLastN.Rd
@@ -4,10 +4,12 @@
 \alias{statscnQueryLastN}
 \title{fetch the lastN data}
 \usage{
-statscnQueryLastN(n)
+statscnQueryLastN(n, lang = "zh")
 }
 \arguments{
 \item{n}{the number of rows to be fetched}
+
+\item{lang}{string value, one of c("zh","en")}
 }
 \value{
 the last n rows data in the latest query

--- a/man/statscnQueryZb.Rd
+++ b/man/statscnQueryZb.Rd
@@ -4,12 +4,14 @@
 \alias{statscnQueryZb}
 \title{the data categories}
 \usage{
-statscnQueryZb(zbid = "zb", dbcode = "hgnd")
+statscnQueryZb(zbid = "zb", dbcode = "hgnd", lang = "zh")
 }
 \arguments{
 \item{zbid}{the father zb/category id , the root id is 'zb'}
 
 \item{dbcode}{which db will be queried}
+
+\item{lang}{string value, one of c("zh","en")}
 }
 \value{
 the data frame with the sub zbs/categories , if the given zbid is not a Parent zb/category, null list is returned

--- a/man/statscnRegions.Rd
+++ b/man/statscnRegions.Rd
@@ -4,10 +4,12 @@
 \alias{statscnRegions}
 \title{the regions in db}
 \usage{
-statscnRegions(dbcode = "fsnd")
+statscnRegions(dbcode = "fsnd", lang = "zh")
 }
 \arguments{
 \item{dbcode}{the dbcode should be some province db(fs*) , city db(cs*) or internaltional db(gj*)}
+
+\item{lang}{string value, one of c("zh","en")}
 }
 \value{
 the data frame with all the available region codes and names in the db


### PR DESCRIPTION
Since the data.stats.gov.cn site has switched to HTTPS, I corrected the base URL and disabled SSL verification, since I could not verify the certificate.

Additionally, the JSON response format has changed, introducing two new fields, moving the row and column descriptions further back. Before, they were located at index 2, however they are now located at index 4. Hence, selection with `ret[[2]][[2]]` did not work anymore, for example in:

https://github.com/jiang-hang/rstatscn/blob/c3f7f6dd6e3314a700b25bdc59cd35255eac9428/R/rstatscn.R#L90-L92

 I have now switched to named parameters that can easily be adjusted if the JSON format changes again in the future.